### PR TITLE
Add an option to check if the active window is fullscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -O3
 #CFLAGS = -ggdb -Og -fno-omit-frame-pointer -Wall -pedantic -Werror -std=gnu11 -fsanitize=address -D_GNU_SOURCE
-LDFLAGS = -lxdo
+LDFLAGS = -lxdo -lX11
 
 all:
 	$(CC) $(CFLAGS) -o autohide autohide_main.c $(LDFLAGS)

--- a/autohide.h
+++ b/autohide.h
@@ -32,3 +32,7 @@
 // or window must be hidden for this time
 // before polybar will show
 #define CURSOR_WINDOW_DELAY 300
+
+// check if the currently active window is fullscreen
+// do not show the bar if it is
+#define CHECK_FULLSCREEN 0


### PR DESCRIPTION
This PR adds a `CHECK_FULLSCREEN` option and a function to get the active window and check if the EWMH fullscreen state property is set.

If the bar is hidden and `CHECK_FULLSCREEN` is 1 and the active window is fullscreen then the loop will just sleep and not show the bar(s).

Checking for hidden is necessary so the bar can still hide when the mouse is in the region to show the bar and a window is made fullscreen or another desktop is switched with a fullscreen window and then the mouse
leaves the region.